### PR TITLE
Bugfix: Disable usage of heidelpay in internal order creation

### DIFF
--- a/PaymentMethodes/HeidelpayAbstractPaymentMethod.php
+++ b/PaymentMethodes/HeidelpayAbstractPaymentMethod.php
@@ -27,7 +27,7 @@ class HeidelpayAbstractPaymentMethod extends \Magento\Payment\Model\Method\Abstr
 	protected $_code = 'hgwabstract';
 	/**
 	 * PaymentCode
-	 * @var string
+	 * @var boolean
 	 */
 	protected $_isGateway = true;
 	/**
@@ -42,14 +42,19 @@ class HeidelpayAbstractPaymentMethod extends \Magento\Payment\Model\Method\Abstr
 	protected $_canCapturePartial = false;
 	/**
 	 * canRefund
-	 * @var string
+	 * @var boolean
 	 */
 	protected $_canRefund = false;
 	/**
 	 * canRefundInvoicePartial
-	 * @var string
+	 * @var boolean
 	 */
 	protected $_canRefundInvoicePartial = false;
+    /**
+     * canUseInternal
+     * @var boolean
+     */
+    protected $_canUseInternal = true;
 	/**
 	 * form block type
 	 * @var string
@@ -219,7 +224,7 @@ class HeidelpayAbstractPaymentMethod extends \Magento\Payment\Model\Method\Abstr
 	     * @todo replace fixed shop version and plugin version
 	     * */
 	    $this->_heidelpayPaymentMethod->getRequest()->getCriterion()->set('SHOP.TYPE', 'Magento 2.x');
-	    $this->_heidelpayPaymentMethod->getRequest()->getCriterion()->set('SHOPMODULE.VERSION', 'Heidelpay Gateway - 16.11.16');
+	    $this->_heidelpayPaymentMethod->getRequest()->getCriterion()->set('SHOPMODULE.VERSION', 'Heidelpay Gateway - 17.1.20');
 	    
 	    /** @todo should be removed after using heidelpay php-api for every payment method */
 	    //$this->_heidelpayPaymentMethod->getRequest()->getCriterion()->set('secret',$this->_encryptor->getHash($quote->getId().$this->_encryptor->exportKeys()));

--- a/PaymentMethodes/HeidelpayAbstractPaymentMethod.php
+++ b/PaymentMethodes/HeidelpayAbstractPaymentMethod.php
@@ -54,7 +54,7 @@ class HeidelpayAbstractPaymentMethod extends \Magento\Payment\Model\Method\Abstr
      * canUseInternal
      * @var boolean
      */
-    protected $_canUseInternal = true;
+    protected $_canUseInternal = false;
 	/**
 	 * form block type
 	 * @var string

--- a/README.md
+++ b/README.md
@@ -1,56 +1,53 @@
 ![Logo](https://dev.heidelpay.de/devHeidelpay_400_180.jpg)
 
-# Heidelpay payment extension for magento2
+# Heidelpay payment extension for Magento2
 
 This extension for Magento 2 provides a direct integration of the Heidelpay payment methods to your Magento 2 shop. 
 
 Currently supported payment methods are:
-* credit card
-* debit card
+* Credit Card
+* Debit Card
 * Sofortüberweisung
 * PayPal
-* prepayment
+* Prepayment
 
-For more information please visit - https://dev.heidelpay.de/shopmodule/magento/magento-2-x/
+For more information please visit -https://dev.heidelpay.de/magento2/
 
-### SYSTEM REQUIREMENTS
+## SYSTEM REQUIREMENTS
 
-This extension requires PHP 5.6 or PHP7.0. 
-It also depends on the Heidelpay php-api library.   
+This extension requires PHP 5.6 or PHP 7.0. 
+It also depends on the Heidelpay php-api library, which will be installed along with the plugin.  
 
-### LICENSE
+## LICENSE
 
 You can find a copy of this license in [LICENSE.md](LICENSE.md).
 
-### Release notes
+## Release notes
 
 All versions greater than 16.10.17 are based on the heidelpay php-api. (https://github.com/heidelpay/php-api). Please visit https://dev.heidelpay.de/PhpApi/ for the developer documentation.
 
-### Installation
+## Installation
 
-add composer repository
+### Add the heidelpay composer repository
 
-composer config repositories.heidelpay composer https://dev.heidelpay.de/packages
+```composer config repositories.heidelpay composer https://dev.heidelpay.de/packages```
 
-install packages
+### Install the heidelpay Magento 2 composer package
 
-composer  require "heidelpay/php-api:16.10.27"
-composer  require "heidelpay/magento2:16.10.27"
+```composer require "heidelpay/magento2:17.1.20"```
 
-enable extension in Magento
+### Enable the extension in Magento 2
 
-php -f bin/magento module:enable --clear-static-content Heidelpay_Gateway
+```php -f bin/magento module:enable --clear-static-content Heidelpay_Gateway```
 
+### Setup the extension and refresh cache
 
-setup and refresh cache
+```php -f bin/magento setup:upgrade```
 
-php -f bin/magento setup:upgrade
+```php -f bin/magento cache:flush```
 
-php -f bin/magento cache:flush
+```php -f bin/magento setup:di:compile```
 
-php -f bin/magento setup:di:compile
- 
-php -f bin/magento setup:static-content:deploy 
+```php -f bin/magento setup:static-content:deploy```
 
 and you are ready to go.
-

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name" : "heidelpay/magento2",
 	"description" : "heidelpay payment extension for magento 2",
 	"require" : {
-		"php" : "~5.5.0|~5.6.0|~7.0.0",
+		"php" : ">=5.6.0",
 		"magento/module-config" : "<100.2.0",
 		"magento/module-store" : "<100.2.0",
 		"magento/module-checkout" : "<100.2.0",
@@ -12,7 +12,7 @@
 		"magento/module-payment" : "<100.2.0",
 		"magento/module-backend" : "<100.2.0",
 		"magento/framework" : "<100.2.0",
-		"heidelpay/php-api" : "16.10.27"
+		"heidelpay/php-api" : "17.1.17"
 	},
 	"suggest" : {
 		"magento/module-checkout-agreements" : "<100.2.0"
@@ -23,7 +23,7 @@
 		}
 	],
 	"type" : "magento2-module",
-	"version" : "16.11.16",
+	"version" : "17.1.20",
 	"license" : "Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.",
 	"autoload" : {
 		"files" : [
@@ -37,11 +37,17 @@
 		"email" : "support@heidelpay.de"
 	},
 	"homepage" : "https://dev.heidelpay.de",
-	"authors" : [{
+	"authors" : [
+        {
 			"name" : "Jens Richter",
 			"email" : "development@heidelpay.de",
-			"homepage" : "https://dev.heidelpay.de/magento"
-		}
+			"homepage" : "https://dev.heidelpay.de/magento2"
+		},
+        {
+            "name": "Stephano Vogel",
+            "email": "development@heidelpay.de",
+            "homepage": "https://dev.heidelpay.de/magento2"
+        }
 	],
 	"keywords" : [
 		"magento",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name" : "heidelpay/magento2",
-	"description" : "heidelpay payment extension for magento 2",
+	"description" : "This extension for Magento 2 provides a direct integration of the Heidelpay payment methods to your Magento 2 shop.",
 	"require" : {
 		"php" : ">=5.6.0",
 		"magento/module-config" : "<100.2.0",

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -58,7 +58,7 @@
             		<active>0</active>
             		<payment_action>authorize</payment_action>
             		<title><![CDATA[PayPal]]></title>
-                	<channel>31HA07BC8142C5A171744F3D6D155865</channel>
+                	<channel>31HA07BC8142C5A171749A60D979B6E4</channel>
             		<allowspecific>0</allowspecific>
                     <specificcountry></specificcountry>
                     <min_order_total>0</min_order_total>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,5 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
-    <module name="Heidelpay_Gateway" schema_version="16.11.16" setup_version="16.11.16">
+    <module name="Heidelpay_Gateway" schema_version="17.1.20" setup_version="17.1.20">
         <sequence>
             <module name="Magento_Sales" />
             <module name="Magento_Payment" />


### PR DESCRIPTION
- Disabled the selection of heidelpay payment methods when creating orders via the administration panel
- Changed the default PayPal channel to the one mentioned in the documentation
- Raised the php-api version used by the plugin