### PR TITLE
Bugfix: Disable usage of heidelpay in internal order creation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		}
 	],
 	"type" : "magento2-module",
-	"version" : "17.1.20",
+	"version" : "17.1.25",
 	"license" : "Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.",
 	"autoload" : {
 		"files" : [


### PR DESCRIPTION
- Disabled the selection of heidelpay payment methods when creating orders via the administration panel
- Changed the default PayPal channel to the one mentioned in the documentation
- Raised the php-api version used by the plugin