### PR TITLE
Note the version standard in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes - heidelpay Payment Gateway for Magento 2
 
+## Versioning
+
+This project does not follow a versioning standard. Versions are crafted after the dates; for example, the version 17.7.25 was released on July, 25th in 2017
+
 ## 17.7.25
 
 ### Added


### PR DESCRIPTION
Currently, a three point date format is being used (x.y.z). This is commonly
used as part of semver (http://semver.org/), and the author initially presumed
that this project adhered to this format. However, in consultation with the
maintainers of the project, the author discovered this was not the expected 
format, and that instead the version is fashioned after the date.

This commit notes that versioning standard in the changelog, where future
developers may see it as they read release notes.