### PR TITLE
(MAGE2-108) change: compatibility changes for magento 2.2.9 and 2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ incorrectly.
 
 ### Changed 
 - Refactored paymentMethods. Simplify configuration and reduce duplicate code in payment methods.
+- Compatibility with magento 2.2.9 and 2.3.2: Change address handling in checkout.
 
 ## 19.5.8
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ incorrectly.
 
 ### Changed 
 - Refactored paymentMethods. Simplify configuration and reduce duplicate code in payment methods.
-- Compatibility with magento 2.2.9 and 2.3.2: Change address handling in checkout.
+- Compatibility with magento 2.2.9: Change address handling in checkout.
 
 ## 19.5.8
 ### Fixed

--- a/Controller/Index/Index.php
+++ b/Controller/Index/Index.php
@@ -102,15 +102,18 @@ class Index extends HgwAbstract
         /** @var HeidelpayAbstractPaymentMethod $payment */
         $payment = $quote->getPayment()->getMethodInstance();
 
-        try {
-            $payment->validateEqualAddress($quote);
-        } catch (CheckoutValidationException $exception) {
-            $this->messageManager->addErrorMessage($exception->getMessage());
-            return $this->_redirect('checkout/cart/', ['_secure' => true]);
-        } catch (\Exception $exception) {
-            $this->messageManager->addErrorMessage($errorMessage);
-            return $this->_redirect('checkout/cart/', ['_secure' => true]);
+        if($payment->getUseShippingAddressAsBillingAddress()) {
+            try {
+                $payment->validateEqualAddress($quote);
+            } catch (CheckoutValidationException $exception) {
+                $this->messageManager->addErrorMessage($exception->getMessage());
+                return $this->_redirect('checkout/cart/', ['_secure' => true]);
+            } catch (\Exception $exception) {
+                $this->messageManager->addErrorMessage($errorMessage);
+                return $this->_redirect('checkout/cart/', ['_secure' => true]);
+            }
         }
+
 
         // get the response object from the initial request.
         /** @var HeidelpayResponse $response */

--- a/PaymentMethods/Exceptions/CheckoutValidationException.php
+++ b/PaymentMethods/Exceptions/CheckoutValidationException.php
@@ -1,4 +1,16 @@
 <?php
+/**
+ * Exceptions that accur during checkout validation.
+ *
+ * @license Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ * @copyright Copyright © 2016-present heidelpay GmbH. All rights reserved.
+ * @link http://dev.heidelpay.com/magento2
+ * @author David Owusu
+ *
+ * @package heidelpay
+ * @subpackage magento2
+ * @category magento2
+ */
 
 namespace Heidelpay\Gateway\PaymentMethods\Exceptions;
 

--- a/PaymentMethods/Exceptions/CheckoutValidationException.php
+++ b/PaymentMethods/Exceptions/CheckoutValidationException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Heidelpay\Gateway\PaymentMethods\Exceptions;
+
+
+use Exception;
+
+class CheckoutValidationException extends Exception
+{
+
+}

--- a/PaymentMethods/HeidelpayAbstractPaymentMethod.php
+++ b/PaymentMethods/HeidelpayAbstractPaymentMethod.php
@@ -14,6 +14,7 @@ use Heidelpay\Gateway\Model\ResourceModel\Transaction\Collection as TransactionC
 use Heidelpay\Gateway\Model\ResourceModel\Transaction\CollectionFactory as HeidelpayTransactionCollectionFactory;
 use Heidelpay\Gateway\Model\Transaction;
 use Heidelpay\Gateway\Model\TransactionFactory;
+use Heidelpay\Gateway\PaymentMethods\Exceptions\CheckoutValidationException;
 use Heidelpay\PhpBasketApi\Exception\InvalidBasketitemPositionException;
 use Heidelpay\PhpPaymentApi\ParameterGroups\BasketParameterGroup;
 use Heidelpay\PhpPaymentApi\PaymentMethods\PaymentMethodInterface;
@@ -64,6 +65,8 @@ class HeidelpayAbstractPaymentMethod extends AbstractMethod
 {
     /** @var string PaymentCode */
     const CODE = 'hgwabstract';
+
+    protected $useShippingAddressOnly = false;
 
     /** @var boolean */
     protected $_usingBasket;
@@ -442,7 +445,6 @@ class HeidelpayAbstractPaymentMethod extends AbstractMethod
     public function getHeidelpayUrl($quote, array $data = [])
     {
         $this->setupInitialRequest();
-
         $user = $this->getUser($quote);
         $this->_heidelpayPaymentMethod->getRequest()->customerAddress(
             $user['NAME.GIVEN'],                   // Given name
@@ -795,5 +797,42 @@ class HeidelpayAbstractPaymentMethod extends AbstractMethod
         $heidelpayTransaction = $collection->loadByTransactionId($transactionID);
 
         return !$heidelpayTransaction === null && !$heidelpayTransaction->isEmpty();
+    }
+
+    /**
+     * @param Quote $quote
+     * @return bool
+     */
+    protected function isEqualAddress($quote)
+    {
+        $shippingAddress = $quote->getShippingAddress();
+        $billingAddress = $quote->getBillingAddress();
+
+        return ($billingAddress->getFirstname() === $shippingAddress->getFirstname()
+            && $billingAddress->getLastname() === $shippingAddress->getLastname()
+            && $billingAddress->getStreet() === $shippingAddress->getStreet()
+            && $billingAddress->getPostcode() === $shippingAddress->getPostcode()
+            && $billingAddress->getCity() === $shippingAddress->getCity()
+            && $billingAddress->getCountryId() === $shippingAddress->getCountryId()
+            && $billingAddress->getEmail() === $shippingAddress->getEmail()
+            && $billingAddress->getCompany() === $shippingAddress->getCompany()
+            && $billingAddress->getTelephone() === $shippingAddress->getTelephone()
+        );
+    }
+
+    /**
+     * @param Quote $quote
+     */
+    public function validateEqualAddress($quote)
+    {
+        $isEqualAddress = $this->isEqualAddress($quote);
+        $this->_logger->debug('isEqualAddress: ' . ($isEqualAddress ? 'Yes' : 'NO'));
+        $quote->setBillingAddress($quote->getShippingAddress());
+
+        if (!$isEqualAddress && $this->useShippingAddressOnly) {
+            throw new CheckoutValidationException(
+                __('Billing address should be same as shipping address.')
+            );
+        }
     }
 }

--- a/PaymentMethods/HeidelpayAbstractPaymentMethod.php
+++ b/PaymentMethods/HeidelpayAbstractPaymentMethod.php
@@ -66,7 +66,8 @@ class HeidelpayAbstractPaymentMethod extends AbstractMethod
     /** @var string PaymentCode */
     const CODE = 'hgwabstract';
 
-    protected $useShippingAddressOnly = false;
+    /** @var boolean */
+    protected $useShippingAddressAsBillingAddress;
 
     /** @var boolean */
     protected $_usingBasket;
@@ -234,6 +235,7 @@ class HeidelpayAbstractPaymentMethod extends AbstractMethod
         $this->_usingBasket             = false;
         $this->_usingActiveRedirect     = true;
         $this->_formBlockType           = HgwAbstract::class;
+        $this->useShippingAddressAsBillingAddress = false;
     }
 
     /**
@@ -803,7 +805,7 @@ class HeidelpayAbstractPaymentMethod extends AbstractMethod
      * @param Quote $quote
      * @return bool
      */
-    protected function isEqualAddress($quote)
+    protected function billingAddressEqualsShippingAddress($quote)
     {
         $shippingAddress = $quote->getShippingAddress();
         $billingAddress = $quote->getBillingAddress();
@@ -822,17 +824,22 @@ class HeidelpayAbstractPaymentMethod extends AbstractMethod
 
     /**
      * @param Quote $quote
+     * @throws CheckoutValidationException
      */
     public function validateEqualAddress($quote)
     {
-        $isEqualAddress = $this->isEqualAddress($quote);
+        $isEqualAddress = $this->billingAddressEqualsShippingAddress($quote);
         $this->_logger->debug('isEqualAddress: ' . ($isEqualAddress ? 'Yes' : 'NO'));
-        $quote->setBillingAddress($quote->getShippingAddress());
 
-        if (!$isEqualAddress && $this->useShippingAddressOnly) {
+        if (!$isEqualAddress) {
             throw new CheckoutValidationException(
                 __('Billing address should be same as shipping address.')
             );
         }
+    }
+
+    public function getUseShippingAddressAsBillingAddress()
+    {
+        return $this->useShippingAddressAsBillingAddress;
     }
 }

--- a/PaymentMethods/HeidelpayDirectDebitSecuredPaymentMethod.php
+++ b/PaymentMethods/HeidelpayDirectDebitSecuredPaymentMethod.php
@@ -37,6 +37,7 @@ class HeidelpayDirectDebitSecuredPaymentMethod extends HeidelpayAbstractPaymentM
         $this->_canAuthorize = true;
         $this->_canRefund = true;
         $this->_canRefundInvoicePartial = true;
+        $this->useShippingAddressOnly   = true;
     }
 
     /**

--- a/PaymentMethods/HeidelpayDirectDebitSecuredPaymentMethod.php
+++ b/PaymentMethods/HeidelpayDirectDebitSecuredPaymentMethod.php
@@ -37,7 +37,7 @@ class HeidelpayDirectDebitSecuredPaymentMethod extends HeidelpayAbstractPaymentM
         $this->_canAuthorize = true;
         $this->_canRefund = true;
         $this->_canRefundInvoicePartial = true;
-        $this->useShippingAddressOnly   = true;
+        $this->useShippingAddressAsBillingAddress   = true;
     }
 
     /**

--- a/PaymentMethods/HeidelpayInvoiceSecuredPaymentMethod.php
+++ b/PaymentMethods/HeidelpayInvoiceSecuredPaymentMethod.php
@@ -42,7 +42,7 @@ class HeidelpayInvoiceSecuredPaymentMethod extends HeidelpayAbstractPaymentMetho
         $this->_canRefundInvoicePartial = true;
         $this->_usingBasket             = true;
         $this->_formBlockType           = InvoiceSecured::class;
-        $this->useShippingAddressOnly   = true;
+        $this->useShippingAddressAsBillingAddress   = true;
     }
 
     /**
@@ -62,10 +62,6 @@ class HeidelpayInvoiceSecuredPaymentMethod extends HeidelpayAbstractPaymentMetho
             $quote->getBillingAddress()->getEmail(),
             $quote->getPayment()->getMethod()
         );
-
-        if($quote->getBillingAddress() !== $quote->getShippingAddress()) {
-            $quote->setBillingAddress($quote->getShippingAddress());
-        }
 
         // set initial data for the request
         parent::getHeidelpayUrl($quote);

--- a/PaymentMethods/HeidelpayInvoiceSecuredPaymentMethod.php
+++ b/PaymentMethods/HeidelpayInvoiceSecuredPaymentMethod.php
@@ -42,6 +42,7 @@ class HeidelpayInvoiceSecuredPaymentMethod extends HeidelpayAbstractPaymentMetho
         $this->_canRefundInvoicePartial = true;
         $this->_usingBasket             = true;
         $this->_formBlockType           = InvoiceSecured::class;
+        $this->useShippingAddressOnly   = true;
     }
 
     /**
@@ -61,6 +62,10 @@ class HeidelpayInvoiceSecuredPaymentMethod extends HeidelpayAbstractPaymentMetho
             $quote->getBillingAddress()->getEmail(),
             $quote->getPayment()->getMethod()
         );
+
+        if($quote->getBillingAddress() !== $quote->getShippingAddress()) {
+            $quote->setBillingAddress($quote->getShippingAddress());
+        }
 
         // set initial data for the request
         parent::getHeidelpayUrl($quote);

--- a/PaymentMethods/HeidelpayPayPalPaymentMethod.php
+++ b/PaymentMethods/HeidelpayPayPalPaymentMethod.php
@@ -37,6 +37,7 @@ class HeidelpayPayPalPaymentMethod extends HeidelpayAbstractPaymentMethod
         $this->_canCapturePartial = true;
         $this->_canRefund = true;
         $this->_canRefundInvoicePartial = true;
+        $this->useShippingAddressOnly   = true;
     }
 
     /**

--- a/PaymentMethods/HeidelpayPayPalPaymentMethod.php
+++ b/PaymentMethods/HeidelpayPayPalPaymentMethod.php
@@ -37,7 +37,7 @@ class HeidelpayPayPalPaymentMethod extends HeidelpayAbstractPaymentMethod
         $this->_canCapturePartial = true;
         $this->_canRefund = true;
         $this->_canRefundInvoicePartial = true;
-        $this->useShippingAddressOnly   = true;
+        $this->useShippingAddressAsBillingAddress   = true;
     }
 
     /**

--- a/PaymentMethods/HeidelpaySantanderHirePurchasePaymentMethod.php
+++ b/PaymentMethods/HeidelpaySantanderHirePurchasePaymentMethod.php
@@ -45,7 +45,7 @@ class HeidelpaySantanderHirePurchasePaymentMethod extends HeidelpayAbstractPayme
         parent::setup();
         $this->_canAuthorize            = true;
         $this->_usingBasket             = true;
-        $this->useShippingAddressOnly   = true;
+        $this->useShippingAddressAsBillingAddress   = true;
     }
 
     /**
@@ -81,9 +81,6 @@ class HeidelpaySantanderHirePurchasePaymentMethod extends HeidelpayAbstractPayme
         // create the collection factory
         $paymentInfoCollection = $this->paymentInformationCollectionFactory->create();
 
-        $this->_logger->debug('ShippingAddress: ' . print_r($quote->getShippingAddress()->toString(), 1));
-        $this->_logger->debug('Setting Billing address: ' . print_r($quote->getBillingAddress()->toString(), 1));
-
         // load the payment information by store id, customer email address and payment method
         /** @var PaymentInformation $paymentInfo */
         $paymentInfo = $paymentInfoCollection->loadByCustomerInformation(
@@ -91,7 +88,6 @@ class HeidelpaySantanderHirePurchasePaymentMethod extends HeidelpayAbstractPayme
             $quote->getBillingAddress()->getEmail(),
             $quote->getPayment()->getMethod()
         );
-
 
         // set initial data for the request
         parent::getHeidelpayUrl($quote);
@@ -152,26 +148,5 @@ class HeidelpaySantanderHirePurchasePaymentMethod extends HeidelpayAbstractPayme
 
             $this->_paymentHelper->saveTransaction($invoice);
         }
-    }
-
-    /**
-     * @param Quote $quote
-     * @return bool
-     */
-    protected function isEqualAddress($quote)
-    {
-        $shippingAddress = $quote->getShippingAddress();
-        $billingAddress = $quote->getBillingAddress();
-
-        return ($billingAddress->getFirstname() === $shippingAddress->getFirstname()
-            && $billingAddress->getLastname() === $shippingAddress->getLastname()
-            && $billingAddress->getStreet() === $shippingAddress->getStreet()
-            && $billingAddress->getPostcode() === $shippingAddress->getPostcode()
-            && $billingAddress->getCity() === $shippingAddress->getCity()
-            && $billingAddress->getCountryId() === $shippingAddress->getCountryId()
-            && $billingAddress->getEmail() === $shippingAddress->getEmail()
-            && $billingAddress->getCompany() === $shippingAddress->getCompany()
-            && $billingAddress->getTelephone() === $shippingAddress->getTelephone()
-        );
     }
 }

--- a/PaymentMethods/HeidelpaySantanderHirePurchasePaymentMethod.php
+++ b/PaymentMethods/HeidelpaySantanderHirePurchasePaymentMethod.php
@@ -25,6 +25,8 @@ use Magento\Quote\Api\Data\CartInterface;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Invoice;
 use Magento\Sales\Model\Order\Payment\Transaction;
+use Magento\Quote\Model\Quote;
+
 
 /** @noinspection LongInheritanceChainInspection */
 /**
@@ -43,6 +45,7 @@ class HeidelpaySantanderHirePurchasePaymentMethod extends HeidelpayAbstractPayme
         parent::setup();
         $this->_canAuthorize            = true;
         $this->_usingBasket             = true;
+        $this->useShippingAddressOnly   = true;
     }
 
     /**
@@ -78,6 +81,9 @@ class HeidelpaySantanderHirePurchasePaymentMethod extends HeidelpayAbstractPayme
         // create the collection factory
         $paymentInfoCollection = $this->paymentInformationCollectionFactory->create();
 
+        $this->_logger->debug('ShippingAddress: ' . print_r($quote->getShippingAddress()->toString(), 1));
+        $this->_logger->debug('Setting Billing address: ' . print_r($quote->getBillingAddress()->toString(), 1));
+
         // load the payment information by store id, customer email address and payment method
         /** @var PaymentInformation $paymentInfo */
         $paymentInfo = $paymentInfoCollection->loadByCustomerInformation(
@@ -85,6 +91,7 @@ class HeidelpaySantanderHirePurchasePaymentMethod extends HeidelpayAbstractPayme
             $quote->getBillingAddress()->getEmail(),
             $quote->getPayment()->getMethod()
         );
+
 
         // set initial data for the request
         parent::getHeidelpayUrl($quote);
@@ -145,5 +152,26 @@ class HeidelpaySantanderHirePurchasePaymentMethod extends HeidelpayAbstractPayme
 
             $this->_paymentHelper->saveTransaction($invoice);
         }
+    }
+
+    /**
+     * @param Quote $quote
+     * @return bool
+     */
+    protected function isEqualAddress($quote)
+    {
+        $shippingAddress = $quote->getShippingAddress();
+        $billingAddress = $quote->getBillingAddress();
+
+        return ($billingAddress->getFirstname() === $shippingAddress->getFirstname()
+            && $billingAddress->getLastname() === $shippingAddress->getLastname()
+            && $billingAddress->getStreet() === $shippingAddress->getStreet()
+            && $billingAddress->getPostcode() === $shippingAddress->getPostcode()
+            && $billingAddress->getCity() === $shippingAddress->getCity()
+            && $billingAddress->getCountryId() === $shippingAddress->getCountryId()
+            && $billingAddress->getEmail() === $shippingAddress->getEmail()
+            && $billingAddress->getCompany() === $shippingAddress->getCompany()
+            && $billingAddress->getTelephone() === $shippingAddress->getTelephone()
+        );
     }
 }

--- a/i18n/de_DE.csv
+++ b/i18n/de_DE.csv
@@ -25,6 +25,7 @@
 "Insert 0 to disable limit.","Tragen Sie 0 ein um das Limit zu deaktivieren."
 "If 'Debit' is enabled the card will be charged immediately. Otherwise the amount will first be authorised and charged at order creation.","Wenn diese Einstellung auf Ja steht, wird die Karte sofort belastet. Ansonsten wird der Betrag nur reserviert und bei erstellter Bestellung abgebucht."
 "An unexpected error occurred. Please contact us to get further information.","Es ist ein Fehler aufgetreten. Bitte kontaktieren Sie uns für weitere Informationen."
+"Billing address should be same as shipping address.","Bitte wählen Sie die selbe Rechnungsadresse wie Lieferadresse"
 
 "Never","Nie"
 "Same Shipping Address","Selbe Lieferadresse"

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -25,6 +25,7 @@
 "Insert 0 to disable limit.","Insert 0 to disable limit."
 "If 'Debit' is enabled the card will be charged immediately. Otherwise the amount will first be authorised and charged at order creation.","If 'Debit' is enabled the card will be charged immediately. Otherwise the amount will first be authorised and charged at order creation."
 "An unexpected error occurred. Please contact us to get further information.","An unexpected error occurred. Please contact us to get further information."
+"Billing address should be same as shipping address.","Billing address should be same as shipping address."
 
 "Never","Never"
 "Same Shipping Address","Same Shipping Address"

--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -36,7 +36,7 @@
                                                                             <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
                                                                         </item>
                                                                         <item name="hgwpal" xsi:type="array">
-                                                                            <item name="isBillingAddressRequired" xsi:type="boolean">false</item>
+                                                                            <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
                                                                         </item>
                                                                         <item name="hgwpp" xsi:type="array">
                                                                             <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
@@ -48,19 +48,19 @@
                                                                             <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
                                                                         </item>
                                                                         <item name="hgwdds" xsi:type="array">
-                                                                            <item name="isBillingAddressRequired" xsi:type="boolean">false</item>
+                                                                            <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
                                                                         </item>
                                                                         <item name="hgwiv" xsi:type="array">
-                                                                            <item name="isBillingAddressRequired" xsi:type="boolean">false</item>
+                                                                            <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
                                                                         </item>
                                                                         <item name="hgwivs" xsi:type="array">
-                                                                            <item name="isBillingAddressRequired" xsi:type="boolean">false</item>
+                                                                            <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
                                                                         </item>
                                                                         <item name="hgwidl" xsi:type="array">
-                                                                            <item name="isBillingAddressRequired" xsi:type="boolean">false</item>
+                                                                            <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
                                                                         </item>
                                                                         <item name="hgwsanhp" xsi:type="array">
-                                                                            <item name="isBillingAddressRequired" xsi:type="boolean">false</item>
+                                                                            <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
                                                                         </item>
                                                                     </item>
                                                                 </item>

--- a/view/frontend/web/js/view/payment/hgw-payments.js
+++ b/view/frontend/web/js/view/payment/hgw-payments.js
@@ -23,7 +23,7 @@ define(
             },
             {
                 type: 'hgwpal',
-                component: 'Heidelpay_Gateway/js/view/payment/method-renderer/hgw-abstract'
+                component: 'Heidelpay_Gateway/js/view/payment/method-renderer/hgw-paypal'
             },
             {
                 type: 'hgwpp',

--- a/view/frontend/web/js/view/payment/method-renderer/hgw-abstract.js
+++ b/view/frontend/web/js/view/payment/method-renderer/hgw-abstract.js
@@ -31,7 +31,7 @@ define(
 
             defaults: {
                 template: 'Heidelpay_Gateway/payment/heidelpay-form',
-                billingEqualsShipping: false
+                useShippingAddressAsBillingAddress: false
             },
 
             /**
@@ -150,12 +150,12 @@ define(
                 selectPaymentMethodAction(this.getData());
                 checkoutData.setSelectedPaymentMethod(this.item.method);
 
-                if(this.billingEqualsShipping) {
+                if(this.useShippingAddressAsBillingAddress) {
                     selectBillingAddress(quote.shippingAddress());
                 }
 
                 return true;
-            },
+            }
         });
     }
 );

--- a/view/frontend/web/js/view/payment/method-renderer/hgw-abstract.js
+++ b/view/frontend/web/js/view/payment/method-renderer/hgw-abstract.js
@@ -64,7 +64,7 @@ define(
              */
             getFullName: function() {
                 var billingAddress = quote.billingAddress();
-                var name = this.getNameFromAddress(billingAddress)
+                var name = this.getNameFromAddress(billingAddress);
 
                 // fallback, if name isn't set yet.
                 if (name === '') {

--- a/view/frontend/web/js/view/payment/method-renderer/hgw-abstract.js
+++ b/view/frontend/web/js/view/payment/method-renderer/hgw-abstract.js
@@ -7,9 +7,10 @@ define(
         'Magento_Checkout/js/action/select-payment-method',
         'Magento_Checkout/js/checkout-data',
         'Magento_Checkout/js/model/quote',
+        'Magento_Checkout/js/action/select-billing-address',
         'moment'
     ],
-    function ($, Component, placeOrderAction, additionalValidators, selectPaymentMethodAction, checkoutData, quote) {
+    function ($, Component, placeOrderAction, additionalValidators, selectPaymentMethodAction, checkoutData, quote, selectBillingAddress) {
         'use strict';
 
         // add IBAN validator
@@ -29,7 +30,8 @@ define(
             savesAdditionalData: false,
 
             defaults: {
-                template: 'Heidelpay_Gateway/payment/heidelpay-form'
+                template: 'Heidelpay_Gateway/payment/heidelpay-form',
+                billingEqualsShipping: false
             },
 
             /**
@@ -61,21 +63,8 @@ define(
              * Function to receive the customer's full name.
              */
             getFullName: function() {
-                var name = '', billingAddress = quote.billingAddress();
-
-                if (billingAddress !== null) {
-                    if (typeof billingAddress.firstname !== 'undefined' && billingAddress.firstname !== null) {
-                        name += billingAddress.firstname;
-                    }
-
-                    if (typeof billingAddress.middlename !== 'undefined' && billingAddress.middlename !== null) {
-                        name += ' ' + billingAddress.middlename;
-                    }
-
-                    if (typeof billingAddress.lastname !== 'undefined' && billingAddress.lastname !== null) {
-                        name += ' ' + billingAddress.lastname;
-                    }
-                }
+                var billingAddress = quote.billingAddress();
+                var name = this.getNameFromAddress(billingAddress)
 
                 // fallback, if name isn't set yet.
                 if (name === '') {
@@ -96,6 +85,25 @@ define(
                     }
                 }
 
+                return name;
+            },
+
+            getNameFromAddress: function(address) {
+                var name = '';
+
+                if (address !== null) {
+                    if (typeof address.firstname !== 'undefined' && address.firstname !== null) {
+                        name += address.firstname;
+                    }
+
+                    if (typeof address.middlename !== 'undefined' && address.middlename !== null) {
+                        name += ' ' + address.middlename;
+                    }
+
+                    if (typeof address.lastname !== 'undefined' && address.lastname !== null) {
+                        name += ' ' + address.lastname;
+                    }
+                }
                 return name;
             },
 
@@ -141,6 +149,10 @@ define(
 
                 selectPaymentMethodAction(this.getData());
                 checkoutData.setSelectedPaymentMethod(this.item.method);
+
+                if(this.billingEqualsShipping) {
+                    selectBillingAddress(quote.shippingAddress());
+                }
 
                 return true;
             },

--- a/view/frontend/web/js/view/payment/method-renderer/hgw-directdebitsecured.js
+++ b/view/frontend/web/js/view/payment/method-renderer/hgw-directdebitsecured.js
@@ -30,7 +30,7 @@ define(
                 hgwDobMonth: '',
                 hgwDobDay: '',
                 years: [null],
-                billingEqualsShipping: true
+                useShippingAddressAsBillingAddress: true
             },
 
             initialize: function () {

--- a/view/frontend/web/js/view/payment/method-renderer/hgw-directdebitsecured.js
+++ b/view/frontend/web/js/view/payment/method-renderer/hgw-directdebitsecured.js
@@ -29,7 +29,8 @@ define(
                 hgwDobYear: '',
                 hgwDobMonth: '',
                 hgwDobDay: '',
-                years: [null]
+                years: [null],
+                billingEqualsShipping: true
             },
 
             initialize: function () {

--- a/view/frontend/web/js/view/payment/method-renderer/hgw-invoicesecured.js
+++ b/view/frontend/web/js/view/payment/method-renderer/hgw-invoicesecured.js
@@ -27,7 +27,8 @@ define(
                 hgwDobMonth: '',
                 hgwDobDay: '',
                 hgwSalutation: '',
-                years: [null]
+                years: [null],
+                billingEqualsShipping: true
             },
 
             initialize: function () {

--- a/view/frontend/web/js/view/payment/method-renderer/hgw-invoicesecured.js
+++ b/view/frontend/web/js/view/payment/method-renderer/hgw-invoicesecured.js
@@ -28,7 +28,7 @@ define(
                 hgwDobDay: '',
                 hgwSalutation: '',
                 years: [null],
-                billingEqualsShipping: true
+                useShippingAddressAsBillingAddress: true
             },
 
             initialize: function () {

--- a/view/frontend/web/js/view/payment/method-renderer/hgw-paypal.js
+++ b/view/frontend/web/js/view/payment/method-renderer/hgw-paypal.js
@@ -1,0 +1,22 @@
+define(
+    [
+        'jquery',
+        'Heidelpay_Gateway/js/view/payment/method-renderer/hgw-abstract',
+        'Heidelpay_Gateway/js/action/place-order',
+        'Magento_Checkout/js/model/url-builder',
+        'mage/storage',
+        'Magento_Checkout/js/model/payment/additional-validators',
+        'Magento_Customer/js/model/customer',
+        'Magento_Checkout/js/model/quote'
+    ],
+    function ($, Component, placeOrderAction, urlBuilder, storage, additionalValidators, customer, quote) {
+        'use strict';
+
+        return Component.extend({
+            defaults: {
+                billingEqualsShipping: true
+            }
+
+        });
+    }
+);

--- a/view/frontend/web/js/view/payment/method-renderer/hgw-paypal.js
+++ b/view/frontend/web/js/view/payment/method-renderer/hgw-paypal.js
@@ -14,7 +14,7 @@ define(
 
         return Component.extend({
             defaults: {
-                billingEqualsShipping: true
+                useShippingAddressAsBillingAddress: true
             }
 
         });

--- a/view/frontend/web/js/view/payment/method-renderer/hgw-santander-hire-purchase.js
+++ b/view/frontend/web/js/view/payment/method-renderer/hgw-santander-hire-purchase.js
@@ -28,14 +28,12 @@ define(
                 hgwDobDay: '',
                 hgwSalutation: '',
                 years: [null],
-                billingEqualsShipping: true
+                useShippingAddressAsBillingAddress: true
             },
 
             initialize: function () {
                 this._super();
                 this.getAdditionalPaymentInformation();
-
-                //$('#checkbox_billing_equals_shipping').prop('checked', true);
 
                 // init years select menu
                 for (let i = (new Date().getFullYear() - 17); i >= new Date().getFullYear() - 120; i--) {

--- a/view/frontend/web/js/view/payment/method-renderer/hgw-santander-hire-purchase.js
+++ b/view/frontend/web/js/view/payment/method-renderer/hgw-santander-hire-purchase.js
@@ -8,7 +8,7 @@ define(
         'Magento_Checkout/js/model/payment/additional-validators',
         'Magento_Customer/js/model/customer',
         'Magento_Checkout/js/model/quote',
-        'moment'
+        'moment',
     ],
     function ($, Component, placeOrderAction, urlBuilder, storage, additionalValidators, customer, quote, moment) {
         'use strict';
@@ -27,12 +27,15 @@ define(
                 hgwDobMonth: '',
                 hgwDobDay: '',
                 hgwSalutation: '',
-                years: [null]
+                years: [null],
+                billingEqualsShipping: true
             },
 
             initialize: function () {
                 this._super();
                 this.getAdditionalPaymentInformation();
+
+                //$('#checkbox_billing_equals_shipping').prop('checked', true);
 
                 // init years select menu
                 for (let i = (new Date().getFullYear() - 17); i >= new Date().getFullYear() - 120; i--) {
@@ -122,6 +125,7 @@ define(
              */
             validate: function() {
                 var form = $('#hgw-santander-hire-purchase');
+
 
                 return form.validation() && form.validation('isValid');
             }

--- a/view/frontend/web/template/payment/heidelpay-invoice-secured-form.html
+++ b/view/frontend/web/template/payment/heidelpay-invoice-secured-form.html
@@ -25,11 +25,6 @@
         <!-- ko foreach: getRegion('messages') -->
         <!-- ko template: getTemplate() --><!-- /ko -->
         <!--/ko-->
-        <div class="payment-method-billing-address">
-            <!-- ko foreach: $parent.getRegion(getBillingAddressFormName()) -->
-            <!-- ko template: getTemplate() --><!-- /ko -->
-            <!--/ko-->
-        </div>
         <form id="hgw-invoice-secured-form" class="form form-hgw-invoice-secured" data-role="hgw-invoice-form-secured">
             <fieldset class="fieldset payment method" data-bind='attr: {id: "payment_form_" + getCode()}'>
                 <div class="field required">
@@ -155,6 +150,12 @@
                 </div>
             </fieldset>
         </form>
+        <div class="payment-method-billing-address">
+            <!-- ko foreach: $parent.getRegion(getBillingAddressFormName()) -->
+            <!-- ko template: getTemplate() -->
+            <!-- /ko -->
+            <!--/ko-->
+        </div>
         <div class="checkout-agreements-block">
             <!-- ko foreach: $parent.getRegion('before-place-order') -->
             <!-- ko template: getTemplate() --><!-- /ko -->

--- a/view/frontend/web/template/payment/heidelpay-santander-hire-purchase.html
+++ b/view/frontend/web/template/payment/heidelpay-santander-hire-purchase.html
@@ -25,11 +25,6 @@
         <!-- ko foreach: getRegion('messages') -->
         <!-- ko template: getTemplate() --><!-- /ko -->
         <!--/ko-->
-        <div class="payment-method-billing-address">
-            <!-- ko foreach: $parent.getRegion(getBillingAddressFormName()) -->
-            <!-- ko template: getTemplate() --><!-- /ko -->
-            <!--/ko-->
-        </div>
         <img src="https://www.santander.de/media/bilder/logos/logos_privatkunden/logo.gif"/>
         <form id="hgw-santander-hire-purchase" class="form form-hgw-santander-hire-purchase" data-role="hgw-santander-hire-purchase">
                 <fieldset class="fieldset payment method" data-bind='attr: {id: "payment_form_" + getCode()}'>
@@ -156,7 +151,12 @@
                     </div>
                 </fieldset>
             </form>
-
+        <div class="payment-method-billing-address">
+            <!-- ko foreach: $parent.getRegion(getBillingAddressFormName()) -->
+            <!-- ko template: getTemplate() -->
+            <!-- /ko -->
+            <!--/ko-->
+        </div>
         <div class="checkout-agreements-block">
             <!-- ko foreach: $parent.getRegion('before-place-order') -->
             <!-- ko template: getTemplate() --><!-- /ko -->


### PR DESCRIPTION
- activate checkbox for billing address for all payment methods.
- preselect it if payment method is choosen where addresses have to be equal.
- Check addresses before doing request.