### PR TITLE
(MAGE2-227) [fix] Hand over storeId correctly in case of Mainconfig.

### DIFF
--- a/Gateway/Config/HgwMainConfig.php
+++ b/Gateway/Config/HgwMainConfig.php
@@ -47,11 +47,12 @@ class HgwMainConfig implements HgwMainConfigInterface
      * Retrieve config value by path and scope.
      *
      * @param $parameter
+     * @param $storeId
      * @return mixed
      */
-    private function getValue($parameter)
+    private function getValue($parameter, $storeId = null)
     {
-        return $this->scopeConfig->getValue($this->pathPattern . $parameter, ScopeInterface::SCOPE_STORE);
+        return $this->scopeConfig->getValue($this->pathPattern . $parameter, ScopeInterface::SCOPE_STORE, $storeId);
     }
 
     /**


### PR DESCRIPTION
Jetzt wird die StoreId auch von der Mainconfig richtig übergeben.