### PR TITLE
Add fallback to core authorize and capture if payment method is not hgw

### DIFF
--- a/Model/Order/Payment/State/AuthorizeCommand.php
+++ b/Model/Order/Payment/State/AuthorizeCommand.php
@@ -32,6 +32,10 @@ class AuthorizeCommand extends \Magento\Sales\Model\Order\Payment\State\Authoriz
      */
     public function execute(OrderPaymentInterface $payment, $amount, OrderInterface $order)
     {
+        if (strpos($payment->getMethod(), 'hgw') !== 0) {
+            return parent::execute($payment, $amount, $order);
+        }
+
         $state = Order::STATE_NEW;
         $status = $order->getConfig()->getStateDefaultStatus($state);
         $order->setStatus($status)

--- a/Model/Order/Payment/State/CaptureCommand.php
+++ b/Model/Order/Payment/State/CaptureCommand.php
@@ -35,6 +35,10 @@ class CaptureCommand extends \Magento\Sales\Model\Order\Payment\State\CaptureCom
      */
     public function execute(OrderPaymentInterface $payment, $amount, OrderInterface $order)
     {
+        if (strpos($payment->getMethod(), 'hgw') !== 0) {
+            return parent::execute($payment, $amount, $order);
+        }
+
         $state = Order::STATE_PROCESSING;
         $status = Order::STATE_PENDING_PAYMENT;
         


### PR DESCRIPTION
Add fallback to default AuthorizeCommand and CaptureCommand if payment method is not a hgw payment method.